### PR TITLE
Fix-issue with keyword search

### DIFF
--- a/R/mod_search_text.R
+++ b/R/mod_search_text.R
@@ -29,11 +29,14 @@ mod_search_text_server <- function(id, filter_data) {
     ns <- session$ns
 
     output$dynamic_comment_ui <- renderUI({
-      req(text_search())
+      validate(
+        need(text_search(), "Please enter a search term")
+      )
       req(return_data())
 
       tagList(
-        uiOutput(ns("comment_output"))
+        uiOutput(ns("comment_output")) %>%
+          shinycssloaders::withSpinner()
       )
     })
 
@@ -60,17 +63,12 @@ mod_search_text_server <- function(id, filter_data) {
         prep_data_for_comment_table(in_tidy_format = FALSE)
     })
 
-
     ## the comments tables ----
     output$comment_output <- renderUI({
-      validate(
-        need(text_search(), "Please enter a search term")
-      )
-
       mod_comment_download_server(
         ns("comment_download_1"),
         return_data(),
-        filepath = sanitized_search_strings(text_search()) %>%
+        filepath = input_sanitizer(text_search()) %>%
           paste(collapse = "_") %>%
           paste0("-")
       )

--- a/tests/testthat/test-fct_api_pred.R
+++ b/tests/testthat/test-fct_api_pred.R
@@ -63,8 +63,8 @@ test_that("assign_highlevel_categories function is working and API vs Framework 
 })
 
 test_that("api_question_code works", {
-  expect_equal(api_question_code("What did we do well"), "what_good")
-  expect_equal(api_question_code("What could be improved"), "could_improve")
+  expect_equal(api_question_code("What did we do well?"), "what_good")
+  expect_equal(api_question_code("What could be improved?"), "could_improve")
   expect_equal(api_question_code("why that answer"), "nonspecific")
 })
 

--- a/tests/testthat/test-filter_text.R
+++ b/tests/testthat/test-filter_text.R
@@ -1,4 +1,12 @@
 test_that("filter_text works", {
+  
+  # check_match and match_term_or_stem works as expected
+  comment = "There was a bit of a wait, which can’t be helped during shortage of doctors"
+  match_term_or_stem(comment, all, "doctors") |>
+    expect_true()
+  match_term_or_stem(comment, all, "doctor") |>
+    expect_true()
+  
   # lowered_comments works as expected
   expect_equal("this   and ThaT" %>%
     lowered_comments(), "this and that")
@@ -23,7 +31,7 @@ test_that("filter_text works", {
       ),
       comment_type = c("comment_1", "comment_1", "comment_1")
     ),
-    filter_text = "Uick, time, appraisal$, &!",
+    filter_text = "qUick, time, appraisal$, &!",
     comment_type_filter = "comment_1", search_type = "and",
     return_dataframe = FALSE
   )
@@ -48,8 +56,8 @@ test_that("filter_text works", {
 
   expect_equal(test3, c("<hr/>no matching result"))
 
-  # test 4 sanitized_search_strings() work correctly
-  expect_equal(sanitized_search_strings("DocTORS, staffs"), c("doctor", "staff"))
+  # test 4 input_sanitizer() work correctly
+  expect_equal(input_sanitizer("DocTORS, staffs"), c("doctors", "staffs"))
 })
 
 test_that("filter_text works - stemmed words version of each search term are searched and return", {
@@ -66,13 +74,13 @@ test_that("filter_text works - stemmed words version of each search term are sea
   search_type <- "and"
   return_dataframe <- FALSE
 
-  search_strings <- sanitized_search_strings(filter_text)
-  expect_equal(search_strings, c("doctor"))
+  search_strings <- input_sanitizer(filter_text)
+  expect_equal(search_strings, c("doctors"))
 
-  t_d <- filter_df(text_data, comment_type_filter)
-  expect_equal(nrow(t_d), 3)
+  result <- filter_df(text_data, comment_type_filter)
+  expect_equal(nrow(result), 3)
 
-  comments <- t_d |>
+  comments <- result |>
     dplyr::pull(comment_txt)
   expect_equal(comments, c(
     "tricky times, I need emergency doctor appointment",

--- a/tests/testthat/test-search_text.R
+++ b/tests/testthat/test-search_text.R
@@ -40,7 +40,7 @@ test_that("Searching text works", {
     comment_type_filter = "comment_2",
     search_type = "or"
   )
-  expect_equal(nrow(test_text), 8)
+  expect_equal(nrow(test_text), 3)
 
   test_text <- return_search_text(
     text_data = tidy_trust_data,


### PR DESCRIPTION
The stemming feature previously used has been dropped. I am switch from using regrex ro searching for the full word. The new approach to catch more  useful search results is by searching for
a. The key word
b. The plural/singular form (if they are valid words).
By doing this, search for "doctors" or "doctor" will return same result. Also search for "team" will return "team" but not "steam" 
